### PR TITLE
Provide simple markdown version of German comic with background info

### DIFF
--- a/public_engagement/cartoon/de/Comic.md
+++ b/public_engagement/cartoon/de/Comic.md
@@ -1,0 +1,4 @@
+#Comic auf Deutsch
+
+![Seite 1](de_panel0001.png)
+![Seite 2](de_panel0002.png)

--- a/public_engagement/cartoon/de/Comic.md
+++ b/public_engagement/cartoon/de/Comic.md
@@ -1,6 +1,6 @@
 # Comic auf Deutsch
 
-![Download als PDF](https://github.com/DP-3T/documents/raw/master/public_engagement/cartoon/de/comic-de.pdf)
+[Download des Comics als PDF](https://github.com/DP-3T/documents/raw/master/public_engagement/cartoon/de/comic-de.pdf)
 
 ![Seite 1](de_panel0001.png)
 ![Seite 2](de_panel0002.png)

--- a/public_engagement/cartoon/de/Comic.md
+++ b/public_engagement/cartoon/de/Comic.md
@@ -1,4 +1,40 @@
-#Comic auf Deutsch
+# Comic auf Deutsch
+
+![Download als PDF](https://github.com/DP-3T/documents/raw/master/public_engagement/cartoon/de/comic-de.pdf)
 
 ![Seite 1](de_panel0001.png)
 ![Seite 2](de_panel0002.png)
+![Seite 3](de_panel0003.png)
+![Seite 4](de_panel0004.png)
+![Seite 5](de_panel0005.png)
+![Seite 6](de_panel0006.png)
+![Seite 7](de_panel0007.png)
+![Seite 8](de_panel0008.png)
+![Seite 9](de_panel0009.png)
+![Seite 10](de_panel0010.png)
+![Seite 11](de_panel0011.png)
+![Seite 12](de_panel0012.png)
+![Seite 13](de_panel0013.png)
+![Seite 14](de_panel0014.png)
+![Seite 15](de_panel0015.png)
+![Seite 16](de_panel0016.png)
+![Seite 17](de_panel0017.png)
+![Seite 18](de_panel0018.png)
+
+# Übersetzungen
+
+Dieser Comic wurde bereits in verschiedene Sprachen übersetzt. 
+Eine aktuelle Liste findet sich unter
+https://github.com/DP-3T/documents/edit/master/public_engagement/cartoon/
+
+Wir bitten um Hilfe bei der *Übersetzung des Comics*! Wenn Du die Dateien sendest oder m.veale@ucl.ac.uk benachrichtigst, werden wir sie in das Repo hochladen, damit andere sie verwenden können. Wenn möglich, würden wir uns freuen, wenn Du auch Deine Übersetzungen mit der Lizenz CC-0 versehen würdest.
+
+# Sonstiges
+
+Dieser Comic wurde von [Nicky Case](https://ncase.me/) erstellt, um einem breiteren Publikum zu erklären, wie DP-3T funktioniert. Er ist für die Kommunikation vereinfacht und keine exakte Darstellung des Protokolls. Zum Beispiel erlaubt es die einfache Version des Protokolls nicht, die Zeiten für das Hochladen zu wählen, wohingegen die komplexere Version mit Cuckoo-Filtern dies erlaubt (Stand: 8. April).
+
+Die Original-URL, die Du verwenden kannst, um den Comic in Englisch anzusehen, lautet https://ncase.me/contact-tracing/. 
+
+Die gesamte Website ist öffentlich zugänglich, lizenziert CC-0, und [verfügbar auf GitHub](https://github.com/ncase/ncase.github.io).
+
+Es ist auch wichtig, darauf hinzuweisen, dass der Comic Aspekte anzeigt, die über die Spezifikationen des Protokolls hinausgehen, wie z.B. eine Risikobewertung, die mit der Anweisung verbunden ist, zu Hause zu bleiben. Dies ist nur ein Beispiel dafür, wie ein lokaler Algorithmus zur Risikoberechnung aussehen könnte. Das Protokoll ist zwar so konzipiert, dass es die Privatsphäre schützt und dazu beiträgt, ein breites Spektrum von Freiheiten vor schleichender Funktionseinschränkung zu bewahren, aber es erfordert einen durchdachten Einsatz in einer Umgebung mit informierten und menschenrechtlich geschützten Richtlinien, damit es für alle Mitglieder unserer Gemeinschaften funktioniert. Der Comic sollte daher nicht so gelesen werden, dass er über das Protokoll hinausgehende politische Vorschläge des DP-3T-Teams enthält.


### PR DESCRIPTION
There was a feature request to have a simple linkable version of the comic, instead of just a PDF.
This is a simple markdown file which does that.

Currently considering html alternatives for a better styling (github-pages is probably no good; I'll probably ask Nicky whether it's feasible to implement a language switcher at https://github.com/ncase/contact-tracing )