### PR TITLE
Remove (almost) duplicate ref to original comic

### DIFF
--- a/public_engagement/cartoon/README.md
+++ b/public_engagement/cartoon/README.md
@@ -6,8 +6,6 @@ The original URL you can use to easily view the comic is https://ncase.me/contac
 
 It is also important to note that the comic does display aspects that go beyond our protocol's specifications, such as a risk score being linked to an instruction to stay at home, a toy example of what a local risk calculation algorithm might look like. While our protocol is engineered to protect privacy, and to help protect a wide range of liberties from function creep, it requires thoughtful deployment in an environment with informed and human rights protective policies in order to work for all members of our communities. The comic should therefore not be read as providing policy suggestions beyond the protocol from the DP-3T team.
 
-The original URL of the comic is https://ncase.me/contact-tracing/. The whole website is in the public domain, licensed CC-0, and [available on GitHub](https://github.com/ncase/ncase.github.io).
-
 We would like help *translating the comic*! Please translate (fonts are Patrick Hand and Open Sans) and if you send the files or notify m.veale@ucl.ac.uk, we will upload them to the repo for others to use. If possible, we would appreciate you also licensing your translations CC-0.
 
 There is a folder full of [empty panels](empty_panels) for ease of preparation (thanks [GH:mtwestra](www.github.com/mtwestra)).


### PR DESCRIPTION
I think the first reference should stay but up to you to decide